### PR TITLE
修复设置页的指纹选项图标,在深色主题下的显示为黑色的问题

### DIFF
--- a/app/src/main/java/com/ldlywt/note/ui/page/settings/HomeSettingsPage.kt
+++ b/app/src/main/java/com/ldlywt/note/ui/page/settings/HomeSettingsPage.kt
@@ -181,6 +181,7 @@ fun SettingsPreferenceScreen(navController: NavHostController) {
                     ItemSwitcher(
                         state = biometricAuthState,
                         iconPainter = rememberVectorPainter(Icons.Outlined.Fingerprint),
+                        iconColor = SaltTheme.colors.text,
                         onChange = {
                             settingsViewModel.showBiometricPrompt(context as MainActivity)
                         },


### PR DESCRIPTION
修复设置页的指纹选项图标,在深色主题下的显示为黑色的问题